### PR TITLE
Add support for an "authors" collection

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -23,6 +23,7 @@ collections: # A list of collections the CMS should be able to edit
       - {label: "Title", name: "title", widget: "string", tagname: "h1"}
       - {label: "Post Excerpt (used in archive)", name: "excerpt", widget: "string"}
       - {label: "Link Type Post (leave empty for normal posts)", name: "link", widget: "string", required: false}
+      - {label: "Author(s)", name: "authors", widget: "relation", collection: "authors", multiple: true, searchFields: ["title"], valueField: "title", display_fields: ["name"], required: false}
       - {label: "Body", name: "body", widget: "markdown"}
       - {label: "Categories", name: "categories", widget: "select", options: ["association", "network"], required: false}
       - {label: "Tags", name: "tags", widget: "list", required: false}
@@ -105,6 +106,23 @@ collections: # A list of collections the CMS should be able to edit
           - {label: "Image", name: "image", widget: "image", required: false}
           - {label: "Thumbnail for Partner Overview", name: "teaser", widget: "image", required: false}
           - {label: "Label (e.g. for credit)", name: "credit", widget: "string", required: false}
+  - name: "authors"
+    label: "Authors"
+    folder: "_authors/"
+    slug: "{{title}}"
+    create: true
+    editor:
+      preview: false
+    fields:
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Display Name", name: "name", widget: "string"}
+      - {label: "Home page", name: "home", widget: "string", required: false}
+      - {label: "Mail", name: "mail", widget: "string", required: false}
+      - {label: "Twitter handle (without at)", name: "twitter", widget: "string", required: false}
+      - {label: "Linkedin handle", name: "linkedin", widget: "string", required: false}
+      - {label: "Instagram handle", name: "instagram", widget: "string", required: false}
+      - {label: "Facebook page", name: "facebook", widget: "string", required: false}
+      - {label: "Biography", name: "bio", widget: "markdown", required: false}
 {% endraw %}{% if site.cms.has_members %}{% raw %}
   - name: "member"
     label: "Members"


### PR DESCRIPTION
Handled through the admin UI, it is primarily used
to assign authors to articles.
It may be extended to support additional use cases
(for example team members data).